### PR TITLE
Adding #version directive.  Help Windoze

### DIFF
--- a/tests-ci/tests/shaderTests/bindTest.frg
+++ b/tests-ci/tests/shaderTests/bindTest.frg
@@ -1,4 +1,4 @@
-//FILE: bindTest.frg
+#version 110  // OpenGL ES 2.0
 
 #ifdef GL_ES
   precision mediump float;

--- a/tests-ci/tests/shaderTests/shaderBugs.frg
+++ b/tests-ci/tests/shaderTests/shaderBugs.frg
@@ -1,3 +1,4 @@
+#version 110  // OpenGL ES 2.0
 
 #ifdef GL_ES
   precision mediump float;

--- a/tests-ci/tests/shaderTests/shaderTest.frg
+++ b/tests-ci/tests/shaderTests/shaderTest.frg
@@ -1,3 +1,4 @@
+#version 110  // OpenGL ES 2.0
 
 #ifdef GL_ES
   precision mediump float;

--- a/tests-ci/tests/shaderTests/shaderTestD.frg
+++ b/tests-ci/tests/shaderTests/shaderTestD.frg
@@ -1,3 +1,5 @@
+#version 110  // OpenGL ES 2.0
+
 #ifdef GL_ES
   precision mediump float;
 #endif

--- a/tests-ci/tests/shaderTests/uniformsTest.frg
+++ b/tests-ci/tests/shaderTests/uniformsTest.frg
@@ -1,3 +1,5 @@
+#version 110  // OpenGL ES 2.0
+
 #ifdef GL_ES
   precision mediump float;
 #endif


### PR DESCRIPTION

It seems like the OpenGL compiler in the Windows driver *require* this `#version` directive.

Added to test shaders